### PR TITLE
Update dashboard header styling to match library page

### DIFF
--- a/src/features/dashboard/components/DashboardHeader.jsx
+++ b/src/features/dashboard/components/DashboardHeader.jsx
@@ -9,7 +9,7 @@ const DashboardHeader = () => {
 
   return (
     <div className="flex items-center">
-      <h1 className="text-2xl font-bold mb-6 md:mb-0 text-gray-100 mr-4">Dashboard</h1>
+      <h1 className="text-lg font-semibold mb-4 md:mb-0 text-purple-300 truncate mr-4">Dashboard</h1>
       <Button
         variant="ghost"
         size="sm"


### PR DESCRIPTION
Update the dashboard header styling to match the library page header for a consistent visual effect.

* Change the font size to `lg` and font weight to `font-semibold` for the header text.
* Change the text color to `text-purple-300` for the header text.
* Add `truncate` class to the header text for consistent truncation.
* Adjust margin properties to match the library page header.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lion-agi/lion-studio?shareId=738b55a2-ed69-4dc1-8aaf-9313ca79215a).