### PR TITLE
Fix workflow operation panel and lock button behavior

### DIFF
--- a/src/common/components/nodes/BaseNode.jsx
+++ b/src/common/components/nodes/BaseNode.jsx
@@ -78,7 +78,7 @@ const BaseNode = ({
             transform: 'translateY(-50%)', 
             width: '12px', 
             height: '12px',
-            background: `var(--${baseColor}-400)`
+            background: 'transparent'
           }}
           isConnectable={isConnectable}
         />
@@ -91,7 +91,7 @@ const BaseNode = ({
             transform: 'translateY(-50%)', 
             width: '12px', 
             height: '12px',
-            background: `var(--${baseColor}-400)`
+            background: 'transparent'
           }}
           isConnectable={isConnectable}
         />

--- a/src/common/components/nodes/Note.jsx
+++ b/src/common/components/nodes/Note.jsx
@@ -2,29 +2,17 @@ import React from 'react';
 import BaseNode from './BaseNode';
 import { StickyNote } from 'lucide-react';
 
-let noteCounter = 0;
-
-const Note = ({ data, ...props }) => {
-  const nodeLabel = data.label || `unnamed${++noteCounter}`;
-  const nodeTitle = `Note: ${nodeLabel}`;
-  
+const Note = (props) => {
   return (
     <BaseNode 
-      {...props}
-      data={{
-        ...data,
-        label: nodeTitle,
-        originalLabel: nodeLabel,
-        isLabelEditable: true,
-        isTypeEditable: false
-      }}
+      {...props} 
       icon={StickyNote} 
       type="note"
-      baseColor="yellow"
+      baseColor="#EAB308"
       gradientFrom="from-yellow-500/30"
       gradientTo="to-yellow-400/10"
     >
-      {nodeTitle}
+      Note
     </BaseNode>
   );
 };

--- a/src/features/workflow/components/WorkflowEditor.jsx
+++ b/src/features/workflow/components/WorkflowEditor.jsx
@@ -121,7 +121,7 @@ const WorkflowEditorContent = () => {
           height: containerSize.height,
           backgroundColor: backgroundColor,
         }}
-        panOnDrag={!isLocked}
+        panOnDrag
         zoomOnScroll={!isLocked}
         nodesDraggable={!isLocked}
         nodesConnectable={!isLocked}
@@ -143,7 +143,7 @@ const WorkflowEditorContent = () => {
           zoomable 
           pannable
         />
-        <Panel position="top-left">
+        <Panel position="top-left" style={{ top: '10px' }}>
           <div className="space-y-2">
             <NodeCreationPanel />
             <WorkflowOperationsPanel

--- a/src/features/workflow/components/WorkflowOperationsPanel.jsx
+++ b/src/features/workflow/components/WorkflowOperationsPanel.jsx
@@ -7,8 +7,7 @@ import { Switch } from "@/common/components/ui/switch";
 import { Label } from "@/common/components/ui/label";
 import { Input } from "@/common/components/ui/input";
 import { ScrollArea } from "@/common/components/ui/scroll-area";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/common/components/ui/collapsible";
-import { Zap, Save, Upload, PlusCircle, FileJson, Play, Pause, Undo, Redo, Settings, Lock, Unlock, ZoomIn, ZoomOut, RotateCcw, Download, Share, ChevronUp, ChevronDown } from 'lucide-react';
+import { Zap, Save, Upload, PlusCircle, FileJson, Play, Pause, Undo, Redo, Settings, Lock, Unlock, ZoomIn, ZoomOut, RotateCcw, Download, Share } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogFooter } from "@/common/components/ui/dialog";
 import JSONModal from '@/common/components/JSONModal';
 import EdgePropertiesDialog from './EdgePropertiesDialog';
@@ -36,7 +35,6 @@ const WorkflowOperationsPanel = ({
   const [autoSave, setAutoSave] = useState(true);
   const [performanceMode, setPerformanceMode] = useState(false);
   const [theme, setTheme] = useState('dark');
-  const [isCollapsed, setIsCollapsed] = useState(false);
   const [showEdgePropertiesDialog, setShowEdgePropertiesDialog] = useState(false);
   const [selectedEdge, setSelectedEdge] = useState(null);
 
@@ -84,183 +82,176 @@ const WorkflowOperationsPanel = ({
   ];
 
   return (
-    <Card className="bg-gray-800 text-white w-72">
-      <Collapsible open={!isCollapsed} onOpenChange={setIsCollapsed}>
-        <CardHeader className="pb-2">
-          <CollapsibleTrigger asChild>
-            <div className="flex items-center justify-between cursor-pointer">
-              <CardTitle className="text-sm font-medium flex items-center">
-                <Zap className="w-4 h-4 mr-2" />
-                Workflow Operations
-              </CardTitle>
-              {isCollapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
-            </div>
-          </CollapsibleTrigger>
-        </CardHeader>
-        <CollapsibleContent>
-          <CardContent className="pt-2">
-            <ScrollArea className="h-[320px]" style={{ backgroundColor: tempBackgroundColor }}>
-              <div className="grid grid-cols-3 gap-2">
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={handleExportJSON}>
-                        <FileJson className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Export JSON</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+    <Card className="bg-gray-800 text-white w-72 fixed top-2 left-2">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium flex items-center">
+            <Zap className="w-4 h-4 mr-2" />
+            Workflow Operations
+          </CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-2">
+        <ScrollArea className="h-[320px]" style={{ backgroundColor: tempBackgroundColor }}>
+          <div className="grid grid-cols-3 gap-2">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={handleExportJSON}>
+                    <FileJson className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Export JSON</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={handleSave}>
-                        <Save className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Save Workflow</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={handleSave}>
+                    <Save className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Save Workflow</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={handleLoad}>
-                        <Upload className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Load Workflow</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={handleLoad}>
+                    <Upload className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Load Workflow</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={onCreateAgenticFlow}>
-                        <PlusCircle className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>New Agentic Flow</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={onCreateAgenticFlow}>
+                    <PlusCircle className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>New Agentic Flow</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={onUndo} disabled={!canUndo}>
-                        <Undo className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Undo</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={onUndo} disabled={!canUndo}>
+                    <Undo className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Undo</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={onRedo} disabled={!canRedo}>
-                        <Redo className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Redo</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={onRedo} disabled={!canRedo}>
+                    <Redo className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Redo</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={() => setShowSettingsModal(true)}>
-                        <Settings className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Settings</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={() => setShowSettingsModal(true)}>
+                    <Settings className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Settings</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={toggleLock}>
-                        {isLocked ? <Lock className="h-4 w-4" /> : <Unlock className="h-4 w-4" />}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>{isLocked ? 'Unlock' : 'Lock'} Workflow</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={toggleLock}>
+                    {isLocked ? <Lock className="h-4 w-4" /> : <Unlock className="h-4 w-4" />}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{isLocked ? 'Unlock' : 'Lock'} Nodes and Edges</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={onZoomIn}>
-                        <ZoomIn className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Zoom In</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={onZoomIn}>
+                    <ZoomIn className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Zoom In</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={onZoomOut}>
-                        <ZoomOut className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Zoom Out</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={onZoomOut}>
+                    <ZoomOut className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Zoom Out</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon" onClick={onResetView}>
-                        <RotateCcw className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Reset View</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" onClick={onResetView}>
+                    <RotateCcw className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Reset View</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
 
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="outline" size="icon">
-                        <Download className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Download Workflow</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
-            </ScrollArea>
-          </CardContent>
-        </CollapsibleContent>
-      </Collapsible>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon">
+                    <Download className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Download Workflow</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        </ScrollArea>
+      </CardContent>
 
       <JSONModal
         isOpen={showJSONModal}


### PR DESCRIPTION
Remove the collapsible functionality from the Workflow Operations Panel and move it slightly upper.

Update the lock button functionality to only lock nodes and edges, not the canvas.

Modify the edge connection dots to have the same color as their node card's background.

**WorkflowOperationsPanel.jsx**
* Remove the collapsible functionality and move the panel slightly upper.
* Update the lock button functionality to only lock nodes and edges, not the canvas.

**WorkflowEditor.jsx**
* Adjust the position of the WorkflowOperationsPanel to be slightly upper within the ReactFlow component.
* Allow canvas dragging even when nodes and edges are locked.

**BaseNode.jsx**
* Update the edge connection dots to have the same color as their node card's background.

**Note.jsx**
* Modify the Note node to use BaseNode and align with other nodes for style and implementation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lion-agi/lion-studio?shareId=b1f0691c-78de-40fa-b72d-5a3056b1a0b3).